### PR TITLE
Removes relative paths to bin files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "build": "node_modules/.bin/rimraf lib && node_modules/.bin/babel src --out-dir lib --source-maps",
+    "build": "rimraf lib && babel src --out-dir lib --source-maps",
     "lint": "standard",
     "postinstall": "npm run build",
     "prepublish": "npm run build",


### PR DESCRIPTION
#### What's this PR do?

Removes relative paths to rimraf and babel  in the `build` npm run script

#### How should this be manually tested?

* Run `rm -rf node_modules && npm install && npm run build` - confirm that the build script runs as expected.

#### Any background context you want to provide?

When running npm install on the content API repo, npm complains that `node_modules/.bin/babel` does not exist.  I am assuming that it is looking for this executable in relation to the api-content project root.  Luckily, npm attaches executables from the `node_modules/.bin/` directory automagically, so removing the relative paths is OK.

#### Screenshots (if appropriate)

![screen shot 2015-06-04 at 3 05 14 pm](https://cloud.githubusercontent.com/assets/129360/7992150/461bdaca-0acb-11e5-9d21-033ca0554dfa.png)

#### Checklist:
- [X] Code standard review
- [ ] Tests included
- [ ] Documentation provided
- [ ] End user documentation provided

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch