### PR TITLE
Removes postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "rimraf lib && babel src --out-dir lib --source-maps",
     "lint": "standard",
-    "postinstall": "npm run build",
     "prepublish": "npm run build",
     "test": "mocha",
     "watch": "npm run build -- --watch"


### PR DESCRIPTION
#### What's this PR do?

This PR removes the "postinstall" script

#### Where should the reviewer start?

[*package.json*](https://github.com/attn/swagger-express-storage-middleware/pull/11/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L10) -Removes postinstall script

#### How should this be manually tested?

* Run `rm -rf node_modules && npm install` and confirm that the build script runs as expected. 

#### Any background context you want to provide?

* Postinstall is removed in order to avoid potential bugs. Refer to https://github.com/npm/npm/issues/4134#issuecomment-72755576

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
#### Checklist:
- [ ] Code standard review
- [ ] Tests included
- [ ] Documentation provided
- [ ] End user documentation provided

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch