### PR TITLE
Use path parameters when querying storage

### DIFF
--- a/src/adapters/waterline.js
+++ b/src/adapters/waterline.js
@@ -94,7 +94,6 @@ export default class WaterlineAdapter extends Storage {
     })
   }
 
-  // @todo Does this method serve any real purpose?
   findOne (model, query, callback) {
     debug('Finding %s', model)
     this.getModel(model).findOne(query).exec(function (error, resource) {

--- a/src/handlers/collection.js
+++ b/src/handlers/collection.js
@@ -26,7 +26,11 @@ export default function handler (storage) {
 }
 
 function find (req, res, next) {
+  // Remove undefined query paramaters.
   let query = _.omit(req.query, _.isUndefined)
+  // Merge in path parameters (to limit query by relationships).
+  query = _.merge(req.query, req.pathParams)
+  // Find the resources.
   Storage.find(req.swagger.resourceType, query, (err, resources) => {
     return respond(err, resources, res, next)
   })

--- a/src/handlers/helpers.js
+++ b/src/handlers/helpers.js
@@ -2,14 +2,13 @@
 
 let debug = require('debug')('swagger:storage')
 
+import _ from 'lodash'
+
 export function getId (req) {
   let idParam
-  if (req.pathParams && req.swagger.params && req.swagger.params.length) {
-    req.swagger.params.forEach((param) => {
-      if (param.in === 'path') {
-        idParam = param.name
-      }
-    })
+  if (req.pathParams && req.swagger.params) {
+    // Use the last path parameter as the ID.
+    idParam = _.result(_.findLast(req.swagger.params, { in: 'path' }), 'name')
   }
   if (idParam) {
     debug("Parsed ID '%s' from path", req.pathParams[idParam])

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -24,7 +24,7 @@ export default function handler (storage) {
 }
 
 function find (req, res, next) {
-  Storage.findById(req.swagger.resourceType, getId(req), (err, resource) => {
+  Storage.findOne(req.swagger.resourceType, req.pathParams, (err, resource) => {
     return respond(err, resource, res, next)
   })
 }
@@ -50,6 +50,7 @@ function create (req, res, next) {
 // }
 
 function replace (req, res, next) {
+  // @todo Compare ID in path with ID in body.
   // First delete the current resource.
   destroyResource(req, (err, resource) => {
     if (err) {


### PR DESCRIPTION
Fixes #12

This still requires passing the relationship ID in the body when creating sub-resources. This is a limitation of the swagger-express-middleware validation.